### PR TITLE
Add avro message decoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-%YAML 1.1
----
 language: python
 python:
   - 2.6
   - 2.7
   - pypy
-  - 3.2
-  - 3.3
-  - 3.4
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install -r test-requirements.txt coveralls
@@ -15,3 +10,13 @@ install:
 script: nosetests
 after_success:
   - coveralls
+deploy:
+  provider: pypi
+  user: sprockets
+  password:
+    secure: 02suxXeo00vEvsTs8OZWyaH7lJ7Ph1kY9LhYta8K7xnvVRYkfkHDEIzN5HkaVd2Rv+BrwcrxKJDdzQ62sCzQjc33kO9CWIkymUmrgNSb5wFrfPkK0Y9QUUt4x9GTCDDUcVDRrTFAQtthVob/3I5GXUcr0O1wFtJRtmzqgXwnpyxU8nGB39bag0qLSd4uF5a23dReuBGzfxqqJQVulOFfbrZOouSs+D8y6QwYWJUfSaNzlUafBxOk/MAJL6E+Bgl0d7rETlSwb6lquAgg1ooZmir6pXgiGfJEKt/V8KPewHXe+AIfv3LpCmG3burYrk+J1gLonV1DucF3TrhsudQFYqgBKTzk5ABd8nPcQKQTuDhq5Un6U+gv6x7KL1IEppKdY1SKjjpUSRgNqTqEjEkHyy1U4dtVNGU39dg4nEorB884G2IAIiOJVhRb58812PHhAwn6JRDHHouV9LcgulZoapX9H3tmPaxrZt3Q08Nautjnnd+kepKcL+mmXgkTMkYpU6fPL29brN1cZH6jKmRLXp4eUps8CshbbBG0vCaat8V7BvAfKqUHwV8slcCEgf3hbixp9UwviCpRPgjFVL8ph9LJnUU6ElaaHdciktv+a1Nc84rGIMp/IJpYAxt11tgnaiBdb1ORRjfuSJgeGWxbYyB1RqEdD0ntTd7Ye6Kndxw=
+  distributions: "sdist bdist_wheel"
+  on:
+    python: 2.7
+    tags: true
+    all_branches: true

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
 API Reference
 =============
 
+.. automodule:: sprockets.mixins.avro
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@ needs_sphinx = '1.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
-    'sphinxcontrib.httpdomain',
 ]
 templates_path = []
 source_suffix = '.rst'
@@ -24,6 +23,6 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
-    'requests': ('https://requests.readthedocs.org/en/latest/', None),
+    'rejected': ('https://rejected.readthedocs.org/en/latest/', None),
     'sprockets': ('https://sprockets.readthedocs.org/en/latest/', None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,9 +26,7 @@ API Documentation
    api
    examples
 
-Version History
----------------
-.. include:: HISTORY.rst
+.. include:: ../HISTORY.rst
 
 Issues
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-# avro is handled in setup.py
+avro>=1.7,<2

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import codecs
-import sys
 
 import setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,6 @@ install_requires = read_requirements_file('requirements.txt')
 setup_requires = read_requirements_file('setup-requirements.txt')
 tests_require = read_requirements_file('test-requirements.txt')
 
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
-if sys.version_info < (3, 0):
-    install_requires.append('avro')
-    tests_require.append('mock')
-else:
-    install_requires.append('avro-python3')
-
 setuptools.setup(
     name='sprockets.mixins.avro',
     version=sprockets.mixins.avro.__version__,
@@ -52,21 +44,15 @@ setuptools.setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    packages=['sprockets',
-              'sprockets.mixins'],
+    packages=['sprockets', 'sprockets.mixins'],
     package_data={'': ['LICENSE', 'README.md']},
     include_package_data=True,
-    namespace_packages=['sprockets',
-                        'sprockets.mixins'],
+    namespace_packages=['sprockets', 'sprockets.mixins'],
     install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=tests_require,

--- a/sprockets/mixins/avro.py
+++ b/sprockets/mixins/avro.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import sys
 
 try:
     from cStringIO import StringIO

--- a/sprockets/mixins/avro.py
+++ b/sprockets/mixins/avro.py
@@ -1,2 +1,59 @@
+from __future__ import absolute_import
+import sys
+
+try:
+    from cStringIO import StringIO
+except ImportError:  # pragma: no cover
+    from StringIO import StringIO
+
+try:
+    import avro.io
+except ImportError:
+    pass  # valid from setup.py
+
+
 version_info = (0, 0, 0)
 __version__ = '.'.join(str(v) for v in version_info)
+
+
+class Decoder(object):
+    """
+    Mix this in over a rejected Consumer for avro deserialization.
+
+    This mix-in implements the ``body`` property that will automatically
+    deserialize avro datum values using a provided schema.  You are
+    required to implement the :meth:`.get_avro_schema` method so that
+    it returns the appropriate :class:`avro.schema.Schema` instance for
+    this message type.
+
+    *See also*: :class:`rejected.consumer.Consumer` and
+    :class:`rejected.consumer.SmartConsumer`
+
+    """
+
+    def prepare(self):
+        super(Decoder, self).prepare()
+        self.__body_dict = None
+
+    def get_avro_schema(self):  # pragma: no cover
+        """
+        Return the avro schema to use for this message.
+
+        :return: the avro schema instance appropriate to this message
+        :rtype: avro.schema.Schema
+
+        """
+        raise NotImplementedError
+
+    @property
+    def body(self):
+        """Return the fully deserialized message body."""
+        if self.__body_dict is None:
+            body = super(Decoder, self).body
+            if self.content_type == 'application/vnd.apache.avro.datum':
+                decoder = avro.io.BinaryDecoder(StringIO(body))
+                reader = avro.io.DatumReader(self.get_avro_schema())
+                self.__body_dict = reader.read(decoder)
+            else:
+                self.__body_dict = body
+        return self.__body_dict

--- a/tests.py
+++ b/tests.py
@@ -90,7 +90,8 @@ class AvroConsumerTests(unittest.TestCase):
         self.assertTrue(consumer.body is first_body)
 
     def test_that_unicode_message_works(self):
-        consumer = ConcreteConsumer(self.get_avro_binary(u'm\u4e35', 'me@foo.com'),
-                                    'application/vnd.apache.avro.datum')
+        consumer = ConcreteConsumer(
+            self.get_avro_binary(u'm\u4e35', 'me@foo.com'),
+            'application/vnd.apache.avro.datum')
         consumer.prepare()
         self.assertEqual(consumer.body['name'], u'm\u4e35')

--- a/tests.py
+++ b/tests.py
@@ -1,2 +1,96 @@
+import json
 import mock
+import StringIO
 import unittest
+
+from avro import io, schema
+
+import sprockets.mixins.avro
+
+
+SIMPLE_SCHEMA = {
+    'namespace': 'com.aweber.tests',
+    'name': 'SimpleTest',
+    'type': 'record',
+    'fields': [
+        {'name': 'name', 'type': 'string'},
+        {'name': 'email', 'type': 'string'},
+    ],
+}
+
+print('SCHEMA', repr(schema), dir(schema))
+schema_obj = schema.parse(json.dumps(SIMPLE_SCHEMA))
+
+
+class BaseConsumer(object):
+    def __init__(self, settings):
+        self._message = mock.Mock(body=None)
+        self._message.properties = mock.Mock(
+            content_encoding=None,
+            content_type=None,
+            correlation_id='CORRELATION-ID',
+            exchange='exchange',
+            headers={},
+            message_id='MESSAGE-ID',
+            routing_key='routing.key',
+            type=None,
+        )
+        self._message_body = None
+
+    def prepare(self):
+        pass
+
+    @property
+    def content_type(self):
+        return self._message.properties.content_type
+
+    @property
+    def body(self):
+        return self._message_body or self._message.body
+
+
+class ConcreteConsumer(sprockets.mixins.avro.Decoder, BaseConsumer):
+
+    def __init__(self, message_body, content_type):
+        super(ConcreteConsumer, self).__init__({})
+        self._message.body = message_body
+        self._message.properties.content_type = content_type
+
+    def get_avro_schema(self):
+        return schema_obj
+
+
+class AvroConsumerTests(unittest.TestCase):
+
+    @staticmethod
+    def get_avro_binary(name, email):
+        buf = StringIO.StringIO()
+        encoder = io.BinaryEncoder(buf)
+        writer = io.DatumWriter(schema_obj)
+        writer.write({'name': name, 'email': email}, encoder)
+        return buf.getvalue()
+
+    def test_that_avro_message_is_decoded(self):
+        consumer = ConcreteConsumer(self.get_avro_binary('me', 'me@foo.com'),
+                                    'application/vnd.apache.avro.datum')
+        consumer.prepare()
+        self.assertEqual(consumer.body, {'name': 'me', 'email': 'me@foo.com'})
+
+    def test_that_super_is_used_for_other_types(self):
+        consumer = ConcreteConsumer(mock.sentinel.body, 'something/else')
+        consumer.prepare()
+        self.assertEqual(consumer.body, mock.sentinel.body)
+
+    def test_that_body_is_not_decoded_multiple_times(self):
+        consumer = ConcreteConsumer(self.get_avro_binary('me', 'me@foo.com'),
+                                    'application/vnd.apache.avro.datum')
+        consumer.prepare()
+        first_body = consumer.body
+        consumer._message.body = None
+        self.assertTrue(consumer.body is first_body)
+
+    def test_that_unicode_message_works(self):
+        consumer = ConcreteConsumer(self.get_avro_binary(u'm\u4e35', 'me@foo.com'),
+                                    'application/vnd.apache.avro.datum')
+        consumer.prepare()
+        self.assertEqual(consumer.body['name'], u'm\u4e35')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py26,py27
+indexserver =
+	default = http://pypi.colo.lair/simple
+toxworkdir = build/tox
+
+[testenv]
+commands = nosetests []
+deps = -rtest-requirements.txt
+


### PR DESCRIPTION
This PR adds `sprockets.mixins.avro.Decoder` which is a simple class that overloads the `body` property of an underlying class and provides decoding of an avro message body.  The mix in requires that someone in the MRO exposes the underlying message body as the `body` property (e.g., like [rejected.consumer.Consumer](https://rejected.readthedocs.org/en/latest/api_consumer.html#rejected.consumer.Consumer.body) does). The mix in hijacks `body` and will decode avro messages using a specific schema and return the decoded body.  The example shown in [examples.rst](https://github.com/sprockets/sprockets.mixins.avro/blob/9546aa107881737fccb2a8aa1f80c1d0ea157aac/docs/examples.rst) is the target interface.
