### PR TITLE
Switch to codecov.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+source = sprockets/mixins/
+[report]
+exclude_lines =
+	pragma: no cover
+	def __repr__
+ignore_errors = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,15 @@ python:
   - 2.6
   - 2.7
   - pypy
+before_install:
+  - pip install codecov
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - pip install -r test-requirements.txt coveralls
   - pip install -e .
 script: nosetests
 after_success:
-  - coveralls
+  - codecov
 deploy:
   provider: pypi
   user: sprockets

--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ See https://github.com/sprockets/sprockets.mixins.avro/blob/master/HISTORY.rst
 .. |Status| image:: https://travis-ci.org/sprockets/sprockets.mixins.avro.svg?branch=master
    :target: https://travis-ci.org/sprockets/sprockets.mixins.avro
 
-.. |Coverage| image:: https://img.shields.io/coveralls/sprockets/sprockets.mixins.avro.svg?
-   :target: https://coveralls.io/r/sprockets/sprockets.mixins.avro
+.. |Coverage| image:: http://codecov.io/github/sprockets/sprockets.mixins.avro/coverage.svg?branch=master
+   :target: https://codecov.io/github/sprockets/sprockets.mixins.avro?branch=master
 
 .. |Downloads| image:: https://pypip.in/d/sprockets.mixins.avro/badge.svg?
    :target: https://pypi.python.org/pypi/sprockets.mixins.avro

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal = 1
+[nosetests]
+with-coverage = 1
+cover-erase = 1
+cover-package = sprockets.mixins

--- a/sprockets/mixins/avro.py
+++ b/sprockets/mixins/avro.py
@@ -7,7 +7,7 @@ except ImportError:  # pragma: no cover
 
 try:
     import avro.io
-except ImportError:
+except ImportError:  # pragma: no cover
     pass  # valid from setup.py
 
 


### PR DESCRIPTION
This PR switches the project to using codecov.io instead of coveralls.io
